### PR TITLE
First draft of APIs for defining simulation methods

### DIFF
--- a/dynamics.py
+++ b/dynamics.py
@@ -1,0 +1,82 @@
+from abc import ABCMeta, abstractmethod, abstractproperty
+
+
+class Dynamics(object):
+    """
+    Abstract base class defining the Dynamics API used by spectroscopy
+    simulation methods
+
+    To implement a new type of dynamics, inherit from this class, override
+    all abstract methods and define the `rw_freq` attribute in the __init__
+    method.
+
+    Attributes
+    ----------
+    rw_freq : float
+        The frequency of the rotating frame in which these dynamics apply.
+        Typically, `rw_freq` would be defined by the hamiltonian which provides
+        the parameters to initialize a new Dynamics object.
+    """
+    __meta__ = ABCMeta
+
+    @abstractmethod
+    def ground_state(self, subspace):
+        """
+        Ground state for this type of dynamics
+        """
+
+    @abstractmethod
+    def equation_of_motion(self, subspace):
+        """
+        Return the equation of motion these dynamics in the given subspace,
+        a function which takes a state and returns its first time derivative,
+        for use in a numerical integration routine
+        """
+
+    @abstractmethod
+    def dipole_destroy(self, polarization, subspace):
+        """
+        Return a dipole annhilation operator that follows the Operator API for
+        the given polarization and subspace
+        """
+
+    @abstractmethod
+    def dipole_create(self, polarization, subspace):
+        """
+        Return the dipole creation operator that follows the Operator API for
+        the given polarization and subspace
+        """
+
+    @abstractproperty
+    def time_step(self):
+        """
+        The default time step at which to sample dynamics (in the rotating
+        frame)
+        """
+
+
+class Operator(object):
+    """
+    Abstract base class defining the Operator API used by spectroscopy
+    simulation methods
+
+    Operator classes define an extension of a system operator into an abstract
+    object whose commutator and expectation value can be calculated when
+    applied to arbitrary the states defined by Dynamics objects.
+
+    To implement a new type of operator, inherit from this class and override
+    all abstract methods.
+    """
+    __meta__ = ABCMeta
+
+    def negative_imag_commutator(self, state):
+        """Returns -1j times the commutator of this operator with the state"""
+        return -1j * self.commutator(state)
+
+    @abstractmethod
+    def commutator(self, state):
+        """Returns the commutator of this operator with the state"""
+
+    @abstractmethod
+    def expectation_value(self, state):
+        """Returns the expectation value of this operator in the state"""

--- a/pulse.py
+++ b/pulse.py
@@ -1,0 +1,110 @@
+from abc import ABCMeta, abstractmethod
+import numpy as np
+
+from constants import GAUSSIAN_SD_FWHM
+
+
+class Pulse(object):
+    """
+    Abstract base class defining the Pulse API used by spectroscopy
+    simulation methods
+
+    Pulse instances are simply functions which return their complex-valued
+    electric field as a function of time, with additional `t_init` and `t_final`
+    attributes that give set times at which they start and end.
+
+    Attributes
+    ----------
+    t_init : float
+        Initital time for the pulse.
+    t_final : float
+        Final time for the pulse.
+    """
+
+    __meta__ = ABCMeta
+
+    @abstractmethod
+    def __call__(self, t, rw_freq):
+        """
+        Evaluate this pulse at the given time and frequency
+
+        Parameters
+        ----------
+        t : number or np.ndarray
+            Time at which to evaluate the pulse.
+        rw_freq : number
+            Rotating wave frequency (in same units as carrier_freq) at which
+            to evaluate the pulse.
+
+        Returns
+        -------
+        out : number or np.ndarray
+            Complex-values of the pulse electric field at requested time t.
+        """
+
+
+class CustomPulse(Pulse):
+    """
+    Define a Pulse whose field is given by a custom function
+    """
+    def __init__(self, t_init, t_final, call):
+        """
+        Parameters
+        ----------
+        t_init : float
+            Initital time for the pulse.
+        t_final : float
+            Final time for the pulse.
+        call : function
+            Function to call to return the pulse electric field at a given time
+            and rotating wave frequency.
+        """
+        self.t_init = t_init
+        self.t_final = t_final
+        self.call = call
+
+    def __call__(self, t, rw_freq):
+        return self.call(t, rw_freq)
+
+
+class GaussianPulse(Pulse):
+    def __init__(self, carrier_freq, fwhm, t_peak=0, scale=1, freq_convert=1,
+                 pulse_length=3):
+        """
+        Initialize a Gaussian pulse
+
+        Parameters
+        ----------
+        carrier_freq : number
+            Pulse carrier frequency (in frequency units).
+        fwhm : number
+            Pulse full-width-at-half-maximum (in time units).
+        t_peak : number, optional
+            Central peak time for this Gaussian pulse (default 0).
+        scale : number, optional
+            Scale factor which sets the maximum amplitude in the time domain
+            (default 1).
+        freq_convert : number, optional
+            Conversion factor from frequency to time units. Default value is 1;
+            set to constants.CM_FS to specify frequencies in angular cm^-1 and
+            time in fs.
+        t_limits_multiple : number, optional
+            Number of standard deviations before and after t_peak to include in
+            the pulse time limits (default 3).
+        """
+        sigma = GAUSSIAN_SD_FWHM * fwhm
+        self.two_sigma_squared = 2 * sigma ** 2
+
+        self.t_init = t_peak - 3 * sigma
+        self.t_final = t_peak + 3 * sigma
+
+        self.t_peak = t_peak
+        self.carrier_freq = carrier_freq
+        self.scale = scale
+        self.freq_convert = freq_convert
+
+    def __call__(self, t, rw_freq):
+        return (self.scale *
+                np.exp((1j * self.freq_convert * (self.carrier_freq - rw_freq)
+                        * (t - self.t_peak))
+                       - (t - self.t_peak) ** 2 / self.two_sigma_squared))

--- a/simulate.py
+++ b/simulate.py
@@ -1,0 +1,51 @@
+from numpy import conj
+import numpy as np
+
+# TODO (SH): define the integrate function (probably by adapting a simple
+# wrapper of ZVODE) and figure out how to pass it options
+from somewhere import integrate
+
+
+def simulate_pump(dynamics, pump, polarization, time_extra=0, subspace='g,e'):
+    """
+    Simulate time evolution under a pump field
+
+    Parameters
+    ----------
+    dynamics : dynamics.Dynamics
+        Object obeying the Dynamics API.
+    pump : pulse.Pulse instance
+        Object obeying the Pulse API.
+    polarization : string or array
+        String ('x', 'y' or 'z') or three item list giving the polarization of
+        pump-field.
+    time_extra : number, optional
+        Extra time after the end of the pump-pulse for which to integrate
+        dynamics (default 0).
+    subspace : string
+        String indicating the subspace in which to calculate dynamics. Defaults
+        to 'g,e' indicating all ground and single excitation states, an
+        approximation which is valid for weak fields.
+
+    Returns
+    -------
+    t : np.ndarray
+        Times at which the state was simulated
+    states : np.ndarray
+        Two-dimensional array of simulated state vectors at all times t
+    """
+
+    eom = dynamics.equation_of_motion(subspace)
+    V_minus = dynamics.dipole_destroy(polarization, subspace)
+    V_plus = dynamics.dipole_create(polarization, subspace)
+
+    def drho(rho, t):
+        Et = pump(t, dynamics.rw_freq)
+        return (eom(rho)
+                + Et * V_minus.negative_imag_commutator(rho)
+                + conj(Et) * V_plus.negative_imag_commutator(rho))
+
+    rho0 = dynamics.ground_state(subspace)
+    t = np.arange(pump.t_init, pump.t_final + time_extra, dynamics.time_step)
+    states = integrate(drho, rho0, t)
+    return (t, states)


### PR DESCRIPTION
The Pulse, Dynamics and Operator APIs specify the basic way in
which you would define dynamics and laser fields to use in new
spectroscopy simulation methods, such as the 'simulate_pump' function
in simulate.py.

Jan -- what do you think? I am a little worried that my python here is a little too advanced for scientists not used to object oriented code to easily understand. I suppose we can always add another layer later that does everyone through functions. Obviously we'll need lots of examples, too.
