### PR TITLE
Split basis_transform into vector and operator versions

### DIFF
--- a/qspectra/__init__.py
+++ b/qspectra/__init__.py
@@ -7,7 +7,8 @@ from dynamics.unitary import UnitaryModel
 from dynamics.zofe import ZOFEModel
 from hamiltonian import (Hamiltonian, ElectronicHamiltonian,
                          VibronicHamiltonian)
-from operator_tools import unit_vec, basis_transform, all_states
+from operator_tools import (unit_vec, basis_transform_operator,
+                            basis_transform_vector, all_states)
 from polarization import (polarization_vector, check_polarizations,
                           invariant_weights_4th_order, invariant_polarizations,
                           FOURTH_ORDER_INVARIANTS, MAGIC_ANGLE)
@@ -24,7 +25,8 @@ __all__ = ['DebyeBath', 'ArbitraryBath', 'UncoupledBath', 'PseudomodeBath',
            'Hamiltonian', 'ElectronicHamiltonian', 'VibronicHamiltonian',
            'n_excitations', 'matrix_to_ket_vec',
            'ket_vec_to_matrix', 'matrix_to_bra_vec', 'unit_vec',
-           'basis_transform', 'all_states', 'polarization_vector',
+           'basis_transform_operator', 'basis_transform_vector',
+           'all_states', 'polarization_vector',
            'check_polarizations', 'invariant_weights_4th_order',
            'invariant_polarizations', 'FOURTH_ORDER_INVARIANTS', 'CustomPulse',
            'GaussianPulse', 'RedfieldModel', 'UnitaryModel', 'ZOFEModel',

--- a/qspectra/dynamics/redfield.py
+++ b/qspectra/dynamics/redfield.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from ..operator_tools import basis_transform
+from ..operator_tools import basis_transform_operator
 from .liouville_space import (super_commutator_matrix, tensor_to_super,
                               LiouvilleSpaceModel)
 from ..utils import memoized_property
@@ -40,7 +40,7 @@ def redfield_tensor(hamiltonian, subspace='ge', secular=True,
     n_states = hamiltonian.n_states(subspace)
     energies = hamiltonian.E(subspace)
 
-    K = [basis_transform(coupling, hamiltonian.U(subspace))
+    K = [basis_transform_operator(coupling, hamiltonian.U(subspace))
          for coupling in hamiltonian.system_bath_couplings(subspace)]
     xi = np.einsum('iab,icd->abcd', K, K)
 
@@ -89,7 +89,7 @@ def redfield_evolve(hamiltonian, subspace='ge', basis='site', **kwargs):
     R = redfield_dissipator(hamiltonian, subspace, **kwargs)
     L = -1j * super_commutator_matrix(H) - R
     if basis == 'site':
-        return basis_transform(L, hamiltonian.U(subspace).T.conj())
+        return basis_transform_operator(L, hamiltonian.U(subspace).T.conj())
     elif basis == 'exciton':
         return L
     else:

--- a/qspectra/operator_tools.py
+++ b/qspectra/operator_tools.py
@@ -39,12 +39,38 @@ def unit_vec(n, N, dtype=complex):
     return v
 
 
-def basis_transform(X, U):
-    """
-    Transform X, a state vector, operator, vectorized operator or super-
-    operator, into the basis given by the unitary transformation matrix U
+def _infer_basis_transform_matrix(X, U):
+    if U.ndim != 2 or U.shape[0] != U.shape[1]:
+        raise ValueError('basis transformation must be a square matrix')
+    N = len(U)
+    if X.shape[-1] == N:
+        # Hilbert space
+        pass
+    elif X.shape[-1] == N ** 2:
+        # Liouville space
+        U = np.kron(U, U)
+    else:
+        raise ValueError('basis transformation incompatible with '
+                         'operator dimensions')
+    return U
 
-    How to apply the transformation is inferred by the dimensions of X and U.
+
+def basis_transform_operator(X, U):
+    """
+    Transform the operator or super-operator X into the basis given by the
+    unitary transformation matrix U
+
+    Parameters
+    ----------
+    X : np.ndarray
+        Operator as a matrix in Hilbert or Liouville space (must be 2d).
+    U : np.ndarray
+        Basis transformation matrix in Hilbert space (must be 2d).
+
+    Returns
+    -------
+    X_prime : np.ndarray
+        The operator reexpressed in the transformed basis.
 
     References
     ----------
@@ -52,24 +78,44 @@ def basis_transform(X, U):
        and matrix representations of quantum dynamical semigroups. J Math. Phys.
        44, 534-557 (2003).
     """
-    N = len(U)
-    if X.shape == (N,):
-        # X is a vector in Hilbert space
-        return U.T.conj().dot(X)
-    elif X.shape == (N, N):
-        # X is an operator
-        return U.T.conj().dot(X).dot(U)
-    elif X.shape[0] == N ** 2:
-        # X is in Liouville space
-        U_S = np.kron(U, U)
-        if X.shape == (N ** 2,):
-            # X is a vectorized operator
-            return U_S.T.conj().dot(X)
-        elif X.shape == (N ** 2, N ** 2):
-            # X is a super-operator
-            return U_S.T.conj().dot(X).dot(U_S)
-    raise ValueError('basis transformation incompatible with '
-                     'operator dimensions')
+    X = np.asarray(X)
+    U = np.asarray(U)
+    if X.ndim != 2:
+        raise ValueError('operator must have ndim=2')
+    U = _infer_basis_transform_matrix(X, U)
+    return U.T.conj().dot(X).dot(U)
+
+
+def basis_transform_vector(rho, U):
+    """
+    Transform the state vector rho into the basis given by the unitary
+    transformation matrix U
+
+    If rho is a multi-dimensional array, this function broadcasts over all
+    dimensions other than the last one.
+
+    Parameters
+    ----------
+    rho : np.ndarray
+        State vector in Hilbert or Liouville space.
+    U : np.ndarray
+        Basis transformation matrix in Hilbert space (must be 2d).
+
+    Returns
+    -------
+    rho_prime : np.ndarray
+        The state vector in the transformed basis.
+
+    References
+    ----------
+    .. [1] Havel, T. F. Robust procedures for converting among Lindblad, Kraus
+       and matrix representations of quantum dynamical semigroups. J Math. Phys.
+       44, 534-557 (2003).
+    """
+    rho = np.asarray(rho)
+    U = np.asarray(U)
+    U = _infer_basis_transform_matrix(rho, U)
+    return np.einsum('ij,...j->...i', U.T.conj(), rho)
 
 
 def all_states(N, subspace='gef'):

--- a/tests/test_operator_tools.py
+++ b/tests/test_operator_tools.py
@@ -20,6 +20,51 @@ def test_unit_vec():
     assert_allclose(operator_tools.unit_vec(0, 3), [1, 0, 0])
 
 
+class TestBasisTransform(unittest.TestCase):
+    def setUp(self):
+        self.U = np.array([[1, 1], [-1, 1]]) / np.sqrt(2)
+
+    def test_basis_transform_operator(self):
+        X = np.random.randn(4, 4)
+        for U in [np.eye(4), np.eye(2)]:
+            X_prime = operator_tools.basis_transform_operator(X, U)
+            assert_allclose(X, X_prime)
+        with self.assertRaises(ValueError):
+            operator_tools.basis_transform_operator(X, np.eye(3))
+        with self.assertRaises(ValueError):
+            operator_tools.basis_transform_operator(X, np.ones((1, 2)))
+
+        X = np.eye(2)
+        actual = operator_tools.basis_transform_operator(X, self.U)
+        assert_allclose(actual, X)
+
+        X = np.array([[1, -1], [-1, 1]]) / 2.0
+        actual = operator_tools.basis_transform_operator(X, self.U)
+        expected = np.array([[1, 0], [0, 0]])
+        assert_allclose(actual, expected)
+
+    def test_basis_transform_vector(self):
+        for rho in [np.random.randn(4), np.random.randn(3, 4)]:
+            for U in [np.eye(4), np.eye(2)]:
+                rho_prime = operator_tools.basis_transform_vector(rho, U)
+                assert_allclose(rho, rho_prime)
+
+        rho = np.random.randn(3)
+        U = np.ones((3, 2))
+        with self.assertRaises(ValueError):
+            operator_tools.basis_transform_vector(rho, U)
+
+        rho = [1, 0]
+        actual = operator_tools.basis_transform_vector(rho, self.U)
+        expected = np.sqrt([0.5, 0.5])
+        assert_allclose(actual, expected)
+
+        rho = [0.5, -0.5, -0.5, 0.5]
+        actual = operator_tools.basis_transform_vector(rho, self.U)
+        expected = np.array([1, 0, 0, 0])
+        assert_allclose(actual, expected)
+
+
 class TestExtendedStates(unittest.TestCase):
     def setUp(self):
         self.M = np.array([[1., 2 - 2j], [2 + 2j, 3]])


### PR DESCRIPTION
It's not possible to guess which version is desired if we want to allow
broadcasting when handling state vectors.
