### PR TITLE
typo in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ and scipy installed.
 Then, clone the git repository and use `pip`:
 ```
 git clone https://github.com/whaley-group-berkeley/QSpectra.git
-pip install -e qspectra
+pip install -e QSpectra
 ```
 
 I highly recommend using `-e` flag, which keeps the install directory in-place


### PR DESCRIPTION
Many operating systems are case-sensitive, so `pip install -e qspectra` will search for a folder with that casing. However, the GitHub repo has capital Q and S which will be preserved in the `git clone`.